### PR TITLE
chore: smarter pathing for react app

### DIFF
--- a/.github/workflows/render-github.yml
+++ b/.github/workflows/render-github.yml
@@ -31,10 +31,10 @@ jobs:
 
       - name: Build react app
         working-directory: ./mappin-itslive-embed
-        run: npm install && npm run build
+        run: npm install && npm run build-dev
 
       - name: Build
-        run: hugo --minify
+        run: hugo --minify -e development
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -30,10 +30,10 @@ jobs:
 
       - name: Build react app
         working-directory: ./mappin-itslive-embed
-        run: npm install && npm run build
+        run: npm install && npm run build-prod
 
       - name: Build for jpl
-        run: hugo --minify -b https://its-live.jpl.nasa.gov/ -d jpl
+        run: hugo --minify -b https://its-live.jpl.nasa.gov/ -d jpl -e production
 
       - name: Deploy to jpl branch
         uses: peaceiris/actions-gh-pages@v3

--- a/layouts/shortcodes/mappin-embed.html
+++ b/layouts/shortcodes/mappin-embed.html
@@ -1,5 +1,16 @@
 <div class="container">
+  <!-- Link to html -->
+  {{ if eq hugo.Environment "development" }}
+  <!-- I render when in development -->
   <script type="module" src="/itslive-web/mappin-build/mappin-build.js"></script>
   <link rel="stylesheet" href="/itslive-web/mappin-build/mappin-build.css">
-  <div class="container"  id="mappin-embed"></div>
+  <div class="container" id="mappin-embed"></div>
+  {{ end }}
+
+  {{ if eq hugo.Environment "production" }}
+  <!-- I render when in production -->
+  <script type="module" src="/mappin-build/mappin-build.js"></script>
+  <link rel="stylesheet" href="/mappin-build/mappin-build.css">
+  <div class="container" id="mappin-embed"></div>
+  {{ end }}
 </div>

--- a/layouts/shortcodes/mappin-embed.html
+++ b/layouts/shortcodes/mappin-embed.html
@@ -1,5 +1,4 @@
 <div class="container">
-  <!-- Link to html -->
   {{ if eq hugo.Environment "development" }}
   <!-- I render when in development -->
   <script type="module" src="/itslive-web/mappin-build/mappin-build.js"></script>


### PR DESCRIPTION
- added a hugo environment variable to separate
  - production (jpl site)
  - development (gh pages site)
  - NOTE: this does mean for the react widget to work locally you have to run `hugo server -e development`
- Changed short-code to path to the react app differently based on the environment var