### PR TITLE
chore: added script to header layout and updated embed commit

### DIFF
--- a/.github/workflows/render-github.yml
+++ b/.github/workflows/render-github.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: install postcss
         run: npm i postcss postcss-cli autoprefixer

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: install postcss
         run: npm i postcss postcss-cli autoprefixer

--- a/layouts/partials/head/metadata.html
+++ b/layouts/partials/head/metadata.html
@@ -1,0 +1,21 @@
+<!-- DAP Code Script -->
+<script async type="text/javascript" id="_fed_an_ua_tag"
+  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=JPL-jpl-nasa-its-live"></script>
+
+<!-- Copied from https://github.com/betolink/hugo-theme-introduction/blob/80ec94d6a8643df722473b7257dd14909413b7a2/layouts/partials/head/metadata.html -->
+{{ template "_internal/google_analytics.html" . }}
+
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="chrome=1">
+<meta name="HandheldFriendly" content="True">
+<meta name="MobileOptimized" content="320">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="referrer" content="no-referrer">
+{{ if .Site.Params.description }}
+<meta name="description" content="{{ .Site.Params.description }}">{{ end }}
+<title>
+  {{ .Title | humanize | title }}{{ if ne .Title .Site.Title }} - {{ .Site.Title | markdownify }}{{ end }}
+</title>
+<!-- RSS -->
+{{ with .OutputFormats.Get "RSS" }}
+<link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />{{ end }}


### PR DESCRIPTION
- Overwrites [this](https://github.com/betolink/hugo-theme-introduction/blob/1762da549499921a288fcfa309a192205bb9c780/layouts/partials/head/metadata.html) Hugo [Partial Template](https://gohugo.io/templates/partials/) with an added script tag for DAP Analytics which will render on all pages because it's rendered in the [index.html template](https://github.com/betolink/hugo-theme-introduction/blob/1762da549499921a288fcfa309a192205bb9c780/layouts/index.html#L5) and [baseof.html template](https://github.com/betolink/hugo-theme-introduction/blob/1762da549499921a288fcfa309a192205bb9c780/layouts/_default/baseof.html#L5C1-L5C45)

- Updates node version to 18 in GH actions since newer postcss version's no longer support node < 18